### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "url": "https://github.com/tmcw/geojson-stream/issues"
   },
   "dependencies": {
-    "JSONStream": "~0.7.1",
-    "through": "~2.3.4"
+    "JSONStream": "^1.0.0",
+    "through": "^2.3.4"
   },
   "devDependencies": {
     "concat-stream": "~1.0.1",


### PR DESCRIPTION
JSONStream moved to from 0.x to 1.x, apparently without any breaking changes. (See: https://github.com/dominictarr/JSONStream/commits/master?page=2)
